### PR TITLE
Limit compatible dotenv versions to 2.1

### DIFF
--- a/lib/middleman_dato/version.rb
+++ b/lib/middleman_dato/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module MiddlemanDato
-  VERSION = '0.8.0'
+  VERSION = '0.8.1'
 end

--- a/middleman-dato.gemspec
+++ b/middleman-dato.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'middleman-core', ['>= 4.1.10']
   s.add_runtime_dependency 'dato', ['>= 0.3.2']
   s.add_runtime_dependency 'activesupport'
-  s.add_runtime_dependency 'dotenv'
+  s.add_runtime_dependency 'dotenv', ['<= 2.1']
 end


### PR DESCRIPTION
* dotenv > 2.1 takes 2 parameters in the initializer of
  Dotenv::Environment.
* Fixes

```ruby
.../lib/ruby/gems/2.4.0/gems/dotenv-2.4.0/lib/dotenv/environment.rb:7:in `initialize': wrong number 
of arguments (given 1, expected 2) (ArgumentError)
```