### PR TITLE
Avoid evaluating @initialize twice

### DIFF
--- a/lib/middleman_dato/middleman_extension.rb
+++ b/lib/middleman_dato/middleman_extension.rb
@@ -27,6 +27,8 @@ module MiddlemanDato
     def initialize(app, options_hash = {}, &block)
       super
 
+      return if app.mode?(:config)
+
       @loader = loader = Dato::Local::Loader.new(
         client,
         options_hash[:preview]


### PR DESCRIPTION
Turns out that Middleman loads every extension twice -- once with `app.mode === :config`, and another with `app.mode === :server`. This makes the current extension release do everything twice, inflating startup time by 2x.

For reference, see:
1) https://github.com/middleman/middleman/issues/1952#issuecomment-348105969
2) https://github.com/middleman/middleman/blob/3d288197f8310e94e7e785b6dbb96d36b445812b/middleman-core/lib/middleman-core/extensions/external_pipeline.rb#L13