### PR TITLE
Update to use new dotenv version

### DIFF
--- a/middleman-dato.gemspec
+++ b/middleman-dato.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'middleman-core', ['>= 4.1.10']
   s.add_runtime_dependency 'dato', ['>= 0.7.16']
   s.add_runtime_dependency 'activesupport'
-  s.add_runtime_dependency 'dotenv', ['<= 2.1']
+  s.add_runtime_dependency 'dotenv', ["!= 2.2", "!= 2.3", "!= 2.4", "!= 2.5"]
 end


### PR DESCRIPTION
The commit for this line in `middleman-dato` is https://github.com/datocms/middleman-dato/commit/5cabc8d608c3e69f4f1dc236426b7ba152a1a73f

The message states:

>  dotenv > 2.1 takes 2 parameters in the initializer of  Dotenv::Environment.

Dotenv [fixed this](https://github.com/bkeepers/dotenv/commit/6894e83b959411a3877aedc16806fdf7a59316f2) in 2.6.0.

This just limits the bad versions, but allows a newer version of `dotenv`.